### PR TITLE
FIX: Antoninho nerfed from god to regular number guesser

### DIFF
--- a/src/functional/game.js
+++ b/src/functional/game.js
@@ -20,7 +20,7 @@ const findWinner = gameState => ({
     ...gameState,
     winner: gameState.players.reduce(
         (winner, playerState) =>
-            winner || playerState.guessedNumber === gameState.houseGuess ? playerState : null,
+            winner != null ? winner : playerState.guessedNumber === gameState.houseGuess ? playerState : null,
         null
     )
 });


### PR DESCRIPTION
The reduce function would always return `gameState.houseGuess` because the condition would always be true once we had a winner. This meant that the last player would always win.